### PR TITLE
Cache last.fm music data for just 24 hours

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -55,3 +55,7 @@ enableRobotsTXT = true
     toLower = true
     type = 'basic'
     weight = 80
+[caches]
+    [caches.getresource]
+        dir = ':cacheDir/:project'
+        maxAge = '24h'


### PR DESCRIPTION
Default caching makes it so that caching last forever? Things seem off. Let's try whether this fixes it.